### PR TITLE
Force gradle to build before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         run: cp .scripts/build.gradle contrib/groovy-language-server
 
       - name: Publish Package
-        run: gradle publish
+        run: gradle build publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_CICD_TAG: ${{needs.tag.outputs.tag}}


### PR DESCRIPTION
Probably better way to do this but I couldn't figure it out. I suck with gradle.